### PR TITLE
rename metrics group name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ use {
     tokio::{sync::RwLock, task::JoinHandle},
 };
 
+const METRICS_NAME: &str = "mango-bencher";
+
 #[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 pub async fn main() -> anyhow::Result<()> {
     solana_logger::setup_with_default("solana=info");
@@ -241,7 +243,7 @@ pub async fn main() -> anyhow::Result<()> {
                     break;
                 }
                 tokio::time::sleep(Duration::from_secs(60)).await;
-                mango_sim_stats.report(false, "Mango simulation stats");
+                mango_sim_stats.report(false, METRICS_NAME);
             }
         });
         tasks.push(reporting_thread);
@@ -257,6 +259,6 @@ pub async fn main() -> anyhow::Result<()> {
     exit_signal.store(true, Ordering::Relaxed);
 
     futures::future::join_all(tasks).await;
-    mango_sim_stats.report(true, "Mango simulation stats");
+    mango_sim_stats.report(true, METRICS_NAME);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ pub async fn main() -> anyhow::Result<()> {
 
     let nb_users = account_keys_parsed.len();
 
-    let mango_sim_stats = MangoSimulationStats::new(
+    let mut mango_sim_stats = MangoSimulationStats::new(
         nb_users,
         *quotes_per_second as usize,
         number_of_markers_per_mm as usize,
@@ -236,7 +236,7 @@ pub async fn main() -> anyhow::Result<()> {
 
     {
         let exit_signal = exit_signal.clone();
-        let mango_sim_stats = mango_sim_stats.clone();
+        let mut mango_sim_stats = mango_sim_stats.clone();
         let reporting_thread = tokio::spawn(async move {
             loop {
                 if exit_signal.load(Ordering::Relaxed) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ const METRICS_NAME: &str = "mango-bencher";
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 pub async fn main() -> anyhow::Result<()> {
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default("info");
     solana_metrics::set_panic_hook("bench-mango", /*version:*/ None);
 
     let matches = cli::build_args(solana_version::version!()).get_matches();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -162,7 +162,7 @@ impl MangoSimulationStats {
         }
     }
 
-    pub fn report(&self, is_final: bool, name: &'static str) {
+    pub fn report(&mut self, is_final: bool, name: &'static str) {
         let num_sent = self.counters.num_sent.load(Ordering::Relaxed);
         let num_confirmed_txs = self.counters.num_confirmed_txs.load(Ordering::Relaxed);
         let num_successful = self.counters.num_successful.load(Ordering::Relaxed);
@@ -265,16 +265,16 @@ impl MangoSimulationStats {
         );
 
         println!(
-            "Transactions confirmed {:.2}%",
-            (num_confirmed_txs as f64 / num_sent as f64) * 100.0
+            "Transactions confirmed {}%",
+            (num_confirmed_txs * 100).checked_div(num_sent).unwrap_or(0)
         );
         println!(
-            "Transactions successful {:.2}%",
-            (num_successful as f64 / num_sent as f64) * 100.0
+            "Transactions successful {}%",
+            (num_successful * 100).checked_div(num_sent).unwrap_or(0)
         );
         println!(
-            "Transactions timed out {:.2}%",
-            (num_timeout_txs as f64 / num_sent as f64) * 100.0
+            "Transactions timed out {}%",
+            (num_timeout_txs * 100).checked_div(num_sent).unwrap_or(0)
         );
         println!("\n\n");
 
@@ -288,18 +288,22 @@ impl MangoSimulationStats {
             ("num_timeout_txs", num_timeout_txs, i64),
             (
                 "percent_confirmed_txs",
-                (num_confirmed_txs * 100) / num_sent,
+                (num_confirmed_txs * 100).checked_div(num_sent).unwrap_or(0),
                 f64
             ),
             (
                 "percent_successful_txs",
-                (num_confirmed_txs * 100) / num_sent,
+                (num_confirmed_txs * 100).checked_div(num_sent).unwrap_or(0),
                 f64
             ),
-            ("percent_error_txs", (num_error_txs * 100) / num_sent, f64),
+            (
+                "percent_error_txs",
+                (num_error_txs * 100).checked_div(num_sent).unwrap_or(0),
+                f64
+            ),
             (
                 "percent_timeout_txs",
-                (num_timeout_txs * 100) / num_sent,
+                (num_timeout_txs * 100).checked_div(num_sent).unwrap_or(0),
                 f64
             ),
             ("keeper_consume_events_sent", num_consume_events_txs, i64),
@@ -317,5 +321,6 @@ impl MangoSimulationStats {
             ("keeper_update_funding_sent", num_update_funding_txs, i64),
             ("keeper_update_funding_succ", succ_update_funding_txs, i64),
         );
+        self.counters = Counters::default();
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -302,6 +302,20 @@ impl MangoSimulationStats {
                 (num_timeout_txs * 100) / num_sent,
                 f64
             ),
+            ("keeper_consume_events_sent", num_consume_events_txs, i64),
+            ("keeper_consume_events_success", succ_consume_events_txs, i64),
+            ("keeper_cache_price_sent", num_cache_price_txs, i64),
+            ("keeper_cache_price_success", succ_cache_price_txs, i64),
+            ("keeper_update_and_cache_qb_sent", num_update_and_cache_quote_bank_txs, i64),
+            ("keeper_update_and_cache_qb_succ", succ_update_and_cache_quote_bank_txs, i64),
+            ("keeper_update_root_banks_sent", num_update_root_banks_txs, i64),
+            ("keeper_update_root_banks_succ", succ_update_root_banks_txs, i64),
+            ("keeper_cache_root_banks_sent", num_cache_root_banks_txs, i64),
+            ("keeper_cache_root_banks_succ", succ_cache_root_banks_txs, i64),
+            ("keeper_update_perp_cache_sent", num_update_perp_cache_txs, i64),
+            ("keeper_update_perp_cache_succ", succ_update_perp_cache_txs, i64),
+            ("keeper_update_funding_sent", num_update_funding_txs, i64),
+            ("keeper_update_funding_succ", succ_update_funding_txs, i64),
         );
     }
 }


### PR DESCRIPTION
Changes are split by commits:
* Rename metrics name so it is aligned to existing naming convention
* Set log level to info, because `solana=info` will show only solana log lines (quic-related) while here we are primarily insterested in mango-level logs and datapoint
* Report not only client but also keeper statistics to metrics database
* Set all metrics to 0 after each run