### PR TITLE
fix cu consumed computations

### DIFF
--- a/src/confirmation_strategies.rs
+++ b/src/confirmation_strategies.rs
@@ -17,7 +17,8 @@ use solana_sdk::{
     slot_history::Slot,
 };
 use solana_transaction_status::{
-    RewardType, TransactionDetails, UiConfirmedBlock, UiTransactionEncoding,
+    option_serializer::OptionSerializer, RewardType, TransactionDetails, UiConfirmedBlock,
+    UiTransactionEncoding,
 };
 
 use crate::states::{BlockData, TransactionConfirmRecord, TransactionSendRecord};
@@ -65,12 +66,9 @@ pub async fn process_blocks(
                 }
             };
             for signature in &transaction.signatures {
-                let transaction_record_op: Option<(TransactionSendRecord, Instant)> =
-                    transaction_map.remove(signature);
                 // add CU in counter
                 total_cu_consumed = total_cu_consumed.saturating_add(tx_cu_consumed);
-                if let Some(transaction_record) = transaction_record_op {
-                    let transaction_record = transaction_record.0;
+                if let Some((_, (transaction_record, _))) = transaction_map.remove(signature) {
                     mm_transaction_count += 1;
                     mm_cu_consumed = mm_cu_consumed.saturating_add(tx_cu_consumed);
 

--- a/src/confirmation_strategies.rs
+++ b/src/confirmation_strategies.rs
@@ -46,11 +46,18 @@ pub async fn process_blocks(
 
     if let Some(transactions) = &block.transactions {
         let nb_transactions = transactions.len();
-        let mut cu_consumed: u64 = 0;
+        let mut mm_cu_consumed: u64 = 0;
+        let mut total_cu_consumed: u64 = 0;
         for solana_transaction_status::EncodedTransactionWithStatusMeta {
             transaction, meta, ..
         } in transactions
         {
+            let tx_cu_consumed =
+                meta.as_ref()
+                    .map_or(0, |meta| match meta.compute_units_consumed {
+                        OptionSerializer::Some(cu_consumed) => cu_consumed,
+                        _ => 0,
+                    });
             let transaction = match transaction.decode() {
                 Some(tx) => tx,
                 None => {
@@ -58,21 +65,14 @@ pub async fn process_blocks(
                 }
             };
             for signature in &transaction.signatures {
-                let transaction_record_op = {
-                    let rec = transaction_map.get(signature);
-                    rec.map(|x| x.clone())
-                };
+                let transaction_record_op: Option<(TransactionSendRecord, Instant)> =
+                    transaction_map.remove(signature);
                 // add CU in counter
-                if let Some(meta) = &meta {
-                    if let solana_transaction_status::option_serializer::OptionSerializer::Some(x) =
-                        meta.compute_units_consumed
-                    {
-                        cu_consumed = cu_consumed.saturating_add(x);
-                    }
-                }
+                total_cu_consumed = total_cu_consumed.saturating_add(tx_cu_consumed);
                 if let Some(transaction_record) = transaction_record_op {
                     let transaction_record = transaction_record.0;
                     mm_transaction_count += 1;
+                    mm_cu_consumed = mm_cu_consumed.saturating_add(tx_cu_consumed);
 
                     match tx_confirm_records.send(TransactionConfirmRecord {
                         signature: transaction_record.signature.to_string(),
@@ -105,8 +105,6 @@ pub async fn process_blocks(
                         }
                     }
                 }
-
-                transaction_map.remove(signature);
             }
         }
         // push block data
@@ -122,8 +120,8 @@ pub async fn process_blocks(
                 },
                 number_of_mango_simulation_txs: mm_transaction_count,
                 total_transactions: nb_transactions as u64,
-                cu_consumed: 0,
-                cu_consumed_by_mango_simulations: cu_consumed,
+                cu_consumed: total_cu_consumed,
+                cu_consumed_by_mango_simulations: mm_cu_consumed,
                 commitment,
             });
         }


### PR DESCRIPTION
It looks like CU units are computed incorrectly.
Also did some minor refactoring in this part of the code.

When trying to compile get error:
```bash
Compiling mango v3.6.0 (https://github.com/blockworks-foundation/mango-v3.git?tag=v3.6.0#771cabea)
error[E0080]: evaluation of constant value failed
   --> /Users/klykov/.cargo/git/checkouts/mango-v3-9044e8c014b9b2ff/771c/program/src/matching.rs:200:1
    |
200 | const_assert_eq!(size_of::<AnyNode>(), size_of::<InnerNode>());
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
    |
    = note: this error originates in the macro `const_assert` which comes from the expansion of the macro `const_assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
```

which seems to be unrelated with the changes. Do we need to update mango-v3 version?